### PR TITLE
Fix seeds to destroy all participations

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,6 +6,7 @@
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
 
+Participation.destroy_all
 Project.destroy_all
 
 


### PR DESCRIPTION
Détruite les participations pour pouvoir supprimer les projets et rejouer les seeds.